### PR TITLE
add repository metadata to appease npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "memebot",
   "version": "1.0.0",
   "description": "Meme bot",
+  "repository": "https://github.com/Daanisaanwezig/mrMeeseeks",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
npm install throws a warning that the repo url is not defined in package.json. This is a quick fix to address that.